### PR TITLE
Adding nofollow inline meta for links to IG & LinkedIn

### DIFF
--- a/_community/2-students-ask-women-in-tech.md
+++ b/_community/2-students-ask-women-in-tech.md
@@ -24,6 +24,6 @@ She is co-founder and CEO of ADDO AI, an artificial intelligence (AI) solutions 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/S03bRSe1QCw" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 
-<p>Watch Stephanie’s video on <a href="https://www.linkedin.com/feed/update/urn:li:activity:6642230636696440832">Linkedin</a>, <a href="https://www.facebook.com/IMDAsg/videos/639024646900001">Facebook</a>, <a href="https://www.instagram.com/tv/B9dRgB8osWC/?utm_source=ig_web_copy_link">Instagram</a>, <a href="https://youtu.be/S03bRSe1QCw">Youtube</a> and <a href="https://twitter.com/IMDAsg/status/1236475037030309891">Twitter</a>!</p>
+<p>Watch Stephanie’s video on <a href="https://www.linkedin.com/feed/update/urn:li:activity:6642230636696440832" rel="nofollow">Linkedin</a>, <a href="https://www.facebook.com/IMDAsg/videos/639024646900001">Facebook</a>, <a href="https://www.instagram.com/tv/B9dRgB8osWC/?utm_source=ig_web_copy_link" rel="nofollow">Instagram</a>, <a href="https://youtu.be/S03bRSe1QCw">Youtube</a> and <a href="https://twitter.com/IMDAsg/status/1236475037030309891">Twitter</a>!</p>
 
 For BTS photos of the video shoots, click [here](https://photos.google.com/share/AF1QipPoaw5H7CVUulTFbmuxnzHdYm25h6Mi8Zt4WWikUf7qFVAl4X9Ax7rP2MhNvs0lXg?key=ZVE5eXQ1RjN3SU95cFpKMVVPZ2hzR0taeVlJUS1R). 

--- a/_community/2-students-ask-women-in-tech.md
+++ b/_community/2-students-ask-women-in-tech.md
@@ -15,7 +15,7 @@ She is co-founder and CEO of ADDO AI, an artificial intelligence (AI) solutions 
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/1gBy0A5wt6w" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-<p>Watch Ayesha’s video on <a href="https://www.linkedin.com/posts/sgwomenintech_internationalwomensday-sgwomenintech-tech-activity-6642215022351224832-Kvn6">Linkedin</a>, <a href="https://www.facebook.com/IMDAsg/videos/309549806672062/">Facebook</a>, <a href="https://www.instagram.com/tv/B9dPtvsI64J/?utm_source=ig_web_copy_link">Instagram</a>, <a href="https://youtu.be/1gBy0A5wt6w">Youtube</a> and <a href="https://twitter.com/IMDAsg/status/1236472968139509765">Twitter</a>!</p>
+<p>Watch Ayesha’s video on <a href="https://www.linkedin.com/posts/sgwomenintech_internationalwomensday-sgwomenintech-tech-activity-6642215022351224832-Kvn6" rel="nofollow">Linkedin</a>, <a href="https://www.facebook.com/IMDAsg/videos/309549806672062/">Facebook</a>, <a href="https://www.instagram.com/tv/B9dPtvsI64J/?utm_source=ig_web_copy_link" rel="nofollow">Instagram</a>, <a href="https://youtu.be/1gBy0A5wt6w">Youtube</a> and <a href="https://twitter.com/IMDAsg/status/1236472968139509765">Twitter</a>!</p>
 
 <p><strong>Ms Stephanie Hung</strong></p>
 <p><img src="/images/stephanie-hung.jpg"/></p>


### PR DESCRIPTION
To fix SEO problem, adding nofollow directive on link to IG & LinkedIn video that returns HTTP error 429 & 500 even though it could be accessed correctly by user.
This is issue between the Google Crawler robot & IG+LinkedIn platform, unable to solve any other way right now. Could remove if in future the issue was solved between Google & IG+LinkedIn